### PR TITLE
Adds option for Chesapeake color palette

### DIFF
--- a/hydra_visualizer/include/hydra_visualizer/color/colormap_utilities.h
+++ b/hydra_visualizer/include/hydra_visualizer/color/colormap_utilities.h
@@ -174,6 +174,7 @@ enum class DiscretePalette {
 enum class CategoricalPalette {
   COLORBREWER,
   DISTINCT150,
+  CHESAPEAKE,
 };
 
 /**

--- a/hydra_visualizer/src/color/colormap_utilities.cpp
+++ b/hydra_visualizer/src/color/colormap_utilities.cpp
@@ -53,6 +53,8 @@ const std::vector<Color>& lookupColormap(CategoricalPalette cmap) {
   switch (cmap) {
     case CategoricalPalette::COLORBREWER:
       return spark_dsg::colormaps::colorbrewerPalette();
+    case CategoricalPalette::CHESAPEAKE:
+      return spark_dsg::colormaps::chesapeakePalette();
     case CategoricalPalette::DISTINCT150:
     default:
       return spark_dsg::colormaps::distinct150Palette();
@@ -211,7 +213,8 @@ void declare_config(CategoricalColormap::Config& config) {
   enum_field(config.palette,
              "palette",
              {{CategoricalPalette::COLORBREWER, "colorbrewer"},
-              {CategoricalPalette::DISTINCT150, "distinct150"}});
+              {CategoricalPalette::DISTINCT150, "distinct150"},
+              {CategoricalPalette::CHESAPEAKE, "chesapeake"}});
   field(config.default_color, "default_color");
 }
 


### PR DESCRIPTION
This PR adds the option for the Hydra visualizer to use the Chesapeake color palette, defined in [Spark-DSG](https://github.com/MIT-SPARK/Spark-DSG). Note that this PR depends on [Spark-DSG/#103](https://github.com/MIT-SPARK/Spark-DSG/pull/103).